### PR TITLE
docs: fix helm stanza in admin-partitions

### DIFF
--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -174,7 +174,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
     adminPartitions:
       enabled: true
     acls:
-      managedSystemACLs: true
+      manageSystemACLs: true
     enterpriseLicense:
       secretName: license
       secretKey: key


### PR DESCRIPTION
### Description

The sample Helm chart for the Admin Partitions guide has a typo regarding the ACL system that would potentially fail the deployment when a practitioner blindly copy/pastes to deploy.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
