### PR TITLE
docs/sameness: fix typo in connect/manage-traffic/failover/sameness

### DIFF
--- a/website/content/docs/connect/manage-traffic/failover/sameness.mdx
+++ b/website/content/docs/connect/manage-traffic/failover/sameness.mdx
@@ -92,7 +92,7 @@ When a sameness group is configured as the failover default, sameness group fail
 
 All services registered in the admin partition must failover to another member of the sameness group. You cannot choose subsets of services to use the sameness group as the failover default. If groups do not have identical services, or if a service is registered to some group members but not all members, this failover strategy may produce errors.
 
-For more information about specifying sameness group members and failover, refer to [sameness group configuration entry reference](/consul/docs/connects/config-entries/sameness-group).
+For more information about specifying sameness group members and failover, refer to [sameness group configuration entry reference](/consul/docs/connect/config-entries/sameness-group).
 
 ### Failover with a service resolver configuration entry
 


### PR DESCRIPTION
### Description

Fixing a small link typo

### Testing & Reproduction steps

None

### Links

None

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
